### PR TITLE
Api remove hibernate validator

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -100,3 +100,19 @@ Some features will be not sufficiently tested and will only be enabled if you ad
     --seedNodes=localhost:8000 --btcNodes=localhost:18445 --baseCurrencyNetwork=BTC_REGTEST --logLevel=info 
     --useDevPrivilegeKeys=true --bitcoinRegtestHost=NONE --myAddress=172.17.0.1:8003 
     --enableHttpApiExperimentalFeatures"
+
+## Integration tests
+
+Integration tests leverage Docker and run in headless mode. First you need to build docker images for the api:
+
+    cd api
+    docker-compose build
+    ../gradlew testIntegration
+    
+IntelliJ Idea has awesome integration so just right click on `api/src/testIntegration` directory and select 
+`Debug All Tests`.
+
+### Integration tests logging
+
+Due to Travis log length limitations the log level is set to WARN, but if you need to see more details locally
+go to `ContainerFactory` class and set `ENV_LOG_LEVEL_VALUE` property to `debug`.

--- a/api/src/main/java/bisq/api/http/exceptions/ExceptionMappers.java
+++ b/api/src/main/java/bisq/api/http/exceptions/ExceptionMappers.java
@@ -17,7 +17,17 @@
 
 package bisq.api.http.exceptions;
 
+import bisq.api.http.model.ValidationErrorMessage;
+
+import bisq.core.exceptions.ConstraintViolationException;
+import bisq.core.exceptions.ValidationException;
+
 import com.fasterxml.jackson.core.JsonParseException;
+
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -38,6 +48,7 @@ public final class ExceptionMappers {
         environment.register(new ExceptionMappers.EofExceptionMapper(), 1);
         environment.register(new ExceptionMappers.JsonParseExceptionMapper(), 1);
         environment.register(new ExceptionMappers.UnauthorizedExceptionMapper());
+        environment.register(new ExceptionMappers.ValidationExceptionMapper());
     }
 
     public static class EofExceptionMapper implements ExceptionMapper<EofException> {
@@ -58,6 +69,30 @@ public final class ExceptionMappers {
         @Override
         public Response toResponse(UnauthorizedException exception) {
             return Response.status(Response.Status.UNAUTHORIZED).build();
+        }
+    }
+
+    public static class ValidationExceptionMapper implements ExceptionMapper<ValidationException> {
+        @Override
+        public Response toResponse(ValidationException exception) {
+            Response.ResponseBuilder responseBuilder = Response.status(422);
+            String message = exception.getMessage();
+            if (exception instanceof ConstraintViolationException) {
+                List<String> messages = ((ConstraintViolationException) exception).getConstraintViolations().stream().map(constraintViolation -> {
+                    StringBuilder stringBuilder = new StringBuilder();
+                    String propertyPath = constraintViolation.getPropertyPath();
+                    if (propertyPath != null) {
+                        stringBuilder.append(propertyPath).append(" ");
+                    }
+                    return stringBuilder.append(constraintViolation.getMessage()).toString();
+                }).collect(Collectors.toList());
+                responseBuilder.entity(new ValidationErrorMessage(ImmutableList.copyOf(messages)));
+            } else if (message != null) {
+                responseBuilder.entity(new ValidationErrorMessage(ImmutableList.of(message)));
+            } else {
+                responseBuilder.entity(new ValidationErrorMessage(ImmutableList.of()));
+            }
+            return responseBuilder.build();
         }
     }
 }

--- a/api/src/main/java/bisq/api/http/model/PayloadValidator.java
+++ b/api/src/main/java/bisq/api/http/model/PayloadValidator.java
@@ -17,19 +17,13 @@
 
 package bisq.api.http.model;
 
-public class ChangePassword implements Validatable {
+import bisq.core.exceptions.ValidationException;
 
-    public String newPassword;
-    public String oldPassword;
-
-    public ChangePassword() {
-    }
-
-    public ChangePassword(String newPassword, String oldPassword) {
-        this.newPassword = newPassword;
-        this.oldPassword = oldPassword;
-    }
-
-    public void validate() {
+public class PayloadValidator {
+    public void validateRequiredRequestPayload(Validatable data) {
+        if (null == data) {
+            throw new ValidationException("Request payload is required");
+        }
+        data.validate();
     }
 }

--- a/api/src/main/java/bisq/api/http/model/Validatable.java
+++ b/api/src/main/java/bisq/api/http/model/Validatable.java
@@ -17,19 +17,6 @@
 
 package bisq.api.http.model;
 
-public class ChangePassword implements Validatable {
-
-    public String newPassword;
-    public String oldPassword;
-
-    public ChangePassword() {
-    }
-
-    public ChangePassword(String newPassword, String oldPassword) {
-        this.newPassword = newPassword;
-        this.oldPassword = oldPassword;
-    }
-
-    public void validate() {
-    }
+public interface Validatable {
+    void validate();
 }

--- a/api/src/main/java/bisq/api/http/model/ValidationErrorMessage.java
+++ b/api/src/main/java/bisq/api/http/model/ValidationErrorMessage.java
@@ -17,19 +17,21 @@
 
 package bisq.api.http.model;
 
-public class ChangePassword implements Validatable {
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
-    public String newPassword;
-    public String oldPassword;
+import com.google.common.collect.ImmutableList;
 
-    public ChangePassword() {
+public class ValidationErrorMessage {
+    private final ImmutableList<String> errors;
+
+    @JsonCreator
+    public ValidationErrorMessage(@JsonProperty("errors") ImmutableList<String> errors) {
+        this.errors = errors;
     }
 
-    public ChangePassword(String newPassword, String oldPassword) {
-        this.newPassword = newPassword;
-        this.oldPassword = oldPassword;
-    }
-
-    public void validate() {
+    @JsonProperty
+    public ImmutableList<String> getErrors() {
+        return errors;
     }
 }

--- a/api/src/main/java/bisq/api/http/service/endpoint/UserEndpoint.java
+++ b/api/src/main/java/bisq/api/http/service/endpoint/UserEndpoint.java
@@ -18,6 +18,7 @@
 package bisq.api.http.service.endpoint;
 
 import bisq.api.http.model.ChangePassword;
+import bisq.api.http.model.PayloadValidator;
 import bisq.api.http.service.auth.ApiPasswordManager;
 
 import bisq.common.UserThread;
@@ -28,8 +29,6 @@ import javax.inject.Inject;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -46,18 +45,21 @@ import javax.ws.rs.core.Response;
 public class UserEndpoint {
 
     private final ApiPasswordManager apiPasswordManager;
+    private final PayloadValidator payloadValidator;
 
     @Inject
-    public UserEndpoint(ApiPasswordManager apiPasswordManager) {
+    public UserEndpoint(ApiPasswordManager apiPasswordManager, PayloadValidator payloadValidator) {
         this.apiPasswordManager = apiPasswordManager;
+        this.payloadValidator = payloadValidator;
     }
 
     @Operation(summary = "Change password")
     @POST
     @Path("/password")
-    public void changePassword(@Suspended AsyncResponse asyncResponse, @NotNull @Valid ChangePassword data) {
+    public void changePassword(@Suspended AsyncResponse asyncResponse, ChangePassword data) {
         UserThread.execute(() -> {
             try {
+                payloadValidator.validateRequiredRequestPayload(data);
                 apiPasswordManager.changePassword(data.oldPassword, data.newPassword);
                 asyncResponse.resume(Response.noContent().build());
             } catch (Throwable e) {

--- a/api/src/main/java/bisq/api/http/service/endpoint/UserEndpoint.java
+++ b/api/src/main/java/bisq/api/http/service/endpoint/UserEndpoint.java
@@ -29,6 +29,7 @@ import javax.inject.Inject;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -54,7 +55,7 @@ public class UserEndpoint {
     @Operation(summary = "Change password")
     @POST
     @Path("/password")
-    public void changePassword(@Suspended AsyncResponse asyncResponse, @Valid ChangePassword data) {
+    public void changePassword(@Suspended AsyncResponse asyncResponse, @NotNull @Valid ChangePassword data) {
         UserThread.execute(() -> {
             try {
                 apiPasswordManager.changePassword(data.oldPassword, data.newPassword);

--- a/api/src/test/java/bisq/api/http/exceptions/EofExceptionMapperTest.java
+++ b/api/src/test/java/bisq/api/http/exceptions/EofExceptionMapperTest.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.http.exceptions;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+
+
+import javax.ws.rs.core.Response;
+import org.eclipse.jetty.io.EofException;
+
+public class EofExceptionMapperTest {
+
+    @Test
+    public void toResponse_always_statusIs400() {
+        //        Given
+        ExceptionMappers.EofExceptionMapper mapper = new ExceptionMappers.EofExceptionMapper();
+
+        //        When
+        Response response = mapper.toResponse(new EofException());
+
+        //        Then
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    public void toResponse_always_noBody() {
+        //        Given
+        ExceptionMappers.EofExceptionMapper mapper = new ExceptionMappers.EofExceptionMapper();
+
+        //        When
+        Response response = mapper.toResponse(new EofException());
+
+        //        Then
+        Object entity = response.getEntity();
+        assertNull(entity);
+    }
+}

--- a/api/src/test/java/bisq/api/http/exceptions/JsonParseExceptionMapperTest.java
+++ b/api/src/test/java/bisq/api/http/exceptions/JsonParseExceptionMapperTest.java
@@ -1,0 +1,58 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.http.exceptions;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+
+
+import javax.ws.rs.core.Response;
+
+public class JsonParseExceptionMapperTest {
+
+    @Test
+    public void toResponse_always_statusIs400() {
+        //        Given
+        ExceptionMappers.JsonParseExceptionMapper mapper = new ExceptionMappers.JsonParseExceptionMapper();
+
+        //        When
+        Response response = mapper.toResponse(new JsonParseException((JsonParser) null, null));
+
+        //        Then
+        assertEquals(400, response.getStatus());
+    }
+
+    @Test
+    public void toResponse_always_noBody() {
+        //        Given
+        ExceptionMappers.JsonParseExceptionMapper mapper = new ExceptionMappers.JsonParseExceptionMapper();
+
+        //        When
+        Response response = mapper.toResponse(new JsonParseException((JsonParser) null, null));
+
+        //        Then
+        Object entity = response.getEntity();
+        assertNull(entity);
+    }
+}

--- a/api/src/test/java/bisq/api/http/exceptions/UnauthorizedExceptionMapperTest.java
+++ b/api/src/test/java/bisq/api/http/exceptions/UnauthorizedExceptionMapperTest.java
@@ -1,0 +1,55 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.http.exceptions;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+
+
+import javax.ws.rs.core.Response;
+
+public class UnauthorizedExceptionMapperTest {
+
+    @Test
+    public void toResponse_always_statusIs400() {
+        //        Given
+        ExceptionMappers.UnauthorizedExceptionMapper mapper = new ExceptionMappers.UnauthorizedExceptionMapper();
+
+        //        When
+        Response response = mapper.toResponse(new UnauthorizedException());
+
+        //        Then
+        assertEquals(401, response.getStatus());
+    }
+
+    @Test
+    public void toResponse_always_noBody() {
+        //        Given
+        ExceptionMappers.UnauthorizedExceptionMapper mapper = new ExceptionMappers.UnauthorizedExceptionMapper();
+
+        //        When
+        Response response = mapper.toResponse(new UnauthorizedException());
+
+        //        Then
+        Object entity = response.getEntity();
+        assertNull(entity);
+    }
+}

--- a/api/src/test/java/bisq/api/http/exceptions/ValidationExceptionMapperTest.java
+++ b/api/src/test/java/bisq/api/http/exceptions/ValidationExceptionMapperTest.java
@@ -1,0 +1,144 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.http.exceptions;
+
+import bisq.api.http.model.ValidationErrorMessage;
+
+import bisq.core.exceptions.ConstraintViolationException;
+import bisq.core.exceptions.ValidationException;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+
+
+import com.github.javafaker.Faker;
+import javax.ws.rs.core.Response;
+
+public class ValidationExceptionMapperTest {
+
+
+    private static void assertInstanceOfValidationErrorMessage(Object object) {
+        String message = "Response payload is an instance of " + ValidationErrorMessage.class.getSimpleName();
+        assertTrue(message, object instanceof ValidationErrorMessage);
+    }
+
+    @Test
+    public void toResponse_constraintViolationException_statusIs422() {
+        //        Given
+        ExceptionMappers.ValidationExceptionMapper mapper = new ExceptionMappers.ValidationExceptionMapper();
+
+        //        When
+        Response response = mapper.toResponse(new ConstraintViolationException(null));
+
+        //        Then
+        assertEquals(422, response.getStatus());
+    }
+
+    @Test
+    public void toResponse_constraintViolationExceptionWithoutViolations_bodyIsViolationErrorMessageWithEmptyErrorList() {
+        //        Given
+        ExceptionMappers.ValidationExceptionMapper mapper = new ExceptionMappers.ValidationExceptionMapper();
+
+        //        When
+        Response response = mapper.toResponse(new ConstraintViolationException(null));
+
+        //        Then
+        Object entity = response.getEntity();
+        assertNotNull(entity);
+        assertInstanceOfValidationErrorMessage(entity);
+        ValidationErrorMessage payload = (ValidationErrorMessage) entity;
+        assertEquals(Collections.emptyList(), payload.getErrors());
+    }
+
+    @Test
+    public void toResponse_constraintViolationException_bodyIsViolationErrorMessageWithNonEmptyErrorList() {
+        //        Given
+        ExceptionMappers.ValidationExceptionMapper mapper = new ExceptionMappers.ValidationExceptionMapper();
+        ConstraintViolationException.Builder builder = new ConstraintViolationException.Builder();
+        Faker faker = Faker.instance();
+        String propertyPathA = faker.app().name();
+        String messageA = faker.app().version();
+        builder.addViolation(propertyPathA, messageA);
+        String messageB = faker.app().version();
+        builder.addViolation(null, messageB);
+
+        //        When
+        Response response = mapper.toResponse(builder.build());
+
+        //        Then
+        Object entity = response.getEntity();
+        assertNotNull(entity);
+        assertInstanceOfValidationErrorMessage(entity);
+        ValidationErrorMessage payload = (ValidationErrorMessage) entity;
+        assertEquals(new HashSet<>(List.of(propertyPathA + " " + messageA, messageB)), new HashSet<>(payload.getErrors()));
+    }
+
+    @Test
+    public void toResponse_ValidationException_statusIs422() {
+        //        Given
+        ExceptionMappers.ValidationExceptionMapper mapper = new ExceptionMappers.ValidationExceptionMapper();
+        String message = Faker.instance().chuckNorris().fact();
+
+        //        When
+        Response response = mapper.toResponse(new ValidationException(message));
+
+        //        Then
+        assertEquals(422, response.getStatus());
+    }
+
+    @Test
+    public void toResponse_ValidationException_bodyIsViolationErrorMessageWithNonEmptyErrorList() {
+        //        Given
+        ExceptionMappers.ValidationExceptionMapper mapper = new ExceptionMappers.ValidationExceptionMapper();
+        String message = Faker.instance().chuckNorris().fact();
+
+        //        When
+        Response response = mapper.toResponse(new ValidationException(message));
+
+        //        Then
+        Object entity = response.getEntity();
+        assertNotNull(entity);
+        assertInstanceOfValidationErrorMessage(entity);
+        ValidationErrorMessage payload = (ValidationErrorMessage) entity;
+        assertEquals(List.of(message), payload.getErrors());
+    }
+
+    @Test
+    public void toResponse_ValidationExceptionWithoutMessage_bodyIsViolationErrorMessageWithEmptyErrorList() {
+        //        Given
+        ExceptionMappers.ValidationExceptionMapper mapper = new ExceptionMappers.ValidationExceptionMapper();
+
+        //        When
+        Response response = mapper.toResponse(new ValidationException());
+
+        //        Then
+        Object entity = response.getEntity();
+        assertNotNull(entity);
+        assertInstanceOfValidationErrorMessage(entity);
+        ValidationErrorMessage payload = (ValidationErrorMessage) entity;
+        assertEquals(Collections.emptyList(), payload.getErrors());
+    }
+}

--- a/api/src/test/java/bisq/api/http/model/ChangePasswordTest.java
+++ b/api/src/test/java/bisq/api/http/model/ChangePasswordTest.java
@@ -17,19 +17,18 @@
 
 package bisq.api.http.model;
 
-public class ChangePassword implements Validatable {
+import org.junit.Test;
 
-    public String newPassword;
-    public String oldPassword;
+public class ChangePasswordTest {
 
-    public ChangePassword() {
-    }
-
-    public ChangePassword(String newPassword, String oldPassword) {
-        this.newPassword = newPassword;
-        this.oldPassword = oldPassword;
-    }
-
-    public void validate() {
+    @Test
+    public void validate_never_throws() {
+        new ChangePassword().validate();
+        new ChangePassword("", null).validate();
+        new ChangePassword(null, "").validate();
+        new ChangePassword("", "").validate();
+        new ChangePassword("a", "b").validate();
+        new ChangePassword("a", "").validate();
+        new ChangePassword("", "a").validate();
     }
 }

--- a/api/src/test/java/bisq/api/http/model/PayloadValidatorTest.java
+++ b/api/src/test/java/bisq/api/http/model/PayloadValidatorTest.java
@@ -1,0 +1,81 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.http.model;
+
+import bisq.core.exceptions.ValidationException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.hamcrest.Matchers.theInstance;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class PayloadValidatorTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void validateRequiredRequestPayload_nonNull_doesNotThrow() {
+//        Given
+        PayloadValidator payloadValidator = new PayloadValidator();
+        Validatable data = mock(Validatable.class);
+//        When
+        payloadValidator.validateRequiredRequestPayload(data);
+//        Then
+        verify(data, times(1)).validate();
+    }
+
+    @Test
+    public void validateRequiredRequestPayload_nonNull_callsValidateOnData() {
+//        Given
+        PayloadValidator payloadValidator = new PayloadValidator();
+        Validatable data = mock(Validatable.class);
+//        When
+        payloadValidator.validateRequiredRequestPayload(data);
+//        Then
+        verify(data, times(1)).validate();
+    }
+
+    @Test
+    public void validateRequiredRequestPayload_validateThrows_propagatesTheException() {
+//        Given
+        PayloadValidator payloadValidator = new PayloadValidator();
+        Validatable data = mock(Validatable.class);
+        RuntimeException someRandomError = new RuntimeException("Some random error");
+        doThrow(someRandomError).when(data).validate();
+        expectedException.expect(theInstance(someRandomError));
+//        When
+        payloadValidator.validateRequiredRequestPayload(data);
+    }
+
+    @Test
+    public void validateRequiredRequestPayload_null_throwsException() {
+//        Given
+        PayloadValidator payloadValidator = new PayloadValidator();
+        expectedException.expect(ValidationException.class);
+        expectedException.expectMessage("Request payload is required");
+//        When
+        //noinspection ConstantConditions
+        payloadValidator.validateRequiredRequestPayload(null);
+    }
+}

--- a/api/src/test/java/bisq/api/http/service/endpoint/UserEndpointTest.java
+++ b/api/src/test/java/bisq/api/http/service/endpoint/UserEndpointTest.java
@@ -1,0 +1,100 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.http.service.endpoint;
+
+import bisq.api.http.model.ChangePassword;
+import bisq.api.http.model.PayloadValidator;
+import bisq.api.http.service.auth.ApiPasswordManager;
+
+import bisq.core.exceptions.ValidationException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+
+
+import com.github.javafaker.Faker;
+import javax.ws.rs.container.AsyncResponse;
+import javax.ws.rs.core.Response;
+import org.mockito.ArgumentCaptor;
+
+public class UserEndpointTest {
+
+    private Faker faker;
+
+    @Before
+    public void setUp() {
+        faker = Faker.instance();
+    }
+
+    @Test
+    public void changePassword_nullData_resumesWithValidationException() {
+//        Given
+        ArgumentCaptor<ValidationException> argument = ArgumentCaptor.forClass(ValidationException.class);
+        UserEndpoint endpoint = new UserEndpoint(null, new PayloadValidator());
+        AsyncResponse asyncResponse = mock(AsyncResponse.class);
+//        When
+        endpoint.changePassword(asyncResponse, null);
+//        Then
+        verify(asyncResponse).resume(argument.capture());
+        assertEquals(ValidationException.class, argument.getValue().getClass());
+        assertEquals("Request payload is required", argument.getValue().getMessage());
+    }
+
+    @Test
+    public void changePassword_apiPasswordManagerThrows_resumesWithThrownException() {
+//        Given
+        ArgumentCaptor<RuntimeException> argument = ArgumentCaptor.forClass(RuntimeException.class);
+        ApiPasswordManager apiPasswordManager = mock(ApiPasswordManager.class);
+        UserEndpoint endpoint = new UserEndpoint(apiPasswordManager, new PayloadValidator());
+        AsyncResponse asyncResponse = mock(AsyncResponse.class);
+        String newPassword = faker.internet().password();
+        String oldPassword = faker.internet().password();
+        ChangePassword data = new ChangePassword(newPassword, oldPassword);
+        RuntimeException exception = new RuntimeException(faker.lorem().sentence());
+        doThrow(exception)
+                .when(apiPasswordManager).changePassword(oldPassword, newPassword);
+//        When
+        endpoint.changePassword(asyncResponse, data);
+//        Then
+        verify(asyncResponse).resume(argument.capture());
+        assertEquals(exception.getClass(), argument.getValue().getClass());
+        assertEquals(exception.getMessage(), argument.getValue().getMessage());
+    }
+
+    @Test
+    public void changePassword_everythingOK_resumesNoContentResponse() {
+//        Given
+        ArgumentCaptor<Response> argument = ArgumentCaptor.forClass(Response.class);
+        ApiPasswordManager apiPasswordManager = mock(ApiPasswordManager.class);
+        UserEndpoint endpoint = new UserEndpoint(apiPasswordManager, new PayloadValidator());
+        AsyncResponse asyncResponse = mock(AsyncResponse.class);
+        ChangePassword data = new ChangePassword();
+//        When
+        endpoint.changePassword(asyncResponse, data);
+//        Then
+        verify(asyncResponse).resume(argument.capture());
+        assertEquals(Response.Status.NO_CONTENT.getStatusCode(), argument.getValue().getStatus());
+        assertEquals(Response.Status.NO_CONTENT, argument.getValue().getStatusInfo());
+    }
+}

--- a/api/src/testIntegration/java/bisq/api/http/ApiTestHelper.java
+++ b/api/src/testIntegration/java/bisq/api/http/ApiTestHelper.java
@@ -1,0 +1,30 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.http;
+
+@SuppressWarnings("WeakerAccess")
+public final class ApiTestHelper {
+
+    public static void waitForAllServicesToBeReady() throws InterruptedException {
+//        TODO it would be nice to expose endpoint that would respond with 200
+        // PaymentMethod initializes it's static values after all services get initialized
+        int ALL_SERVICES_INITIALIZED_DELAY = 5000;
+        Thread.sleep(ALL_SERVICES_INITIALIZED_DELAY);
+    }
+
+}

--- a/api/src/testIntegration/java/bisq/api/http/ContainerFactory.java
+++ b/api/src/testIntegration/java/bisq/api/http/ContainerFactory.java
@@ -1,0 +1,101 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.http;
+
+import org.arquillian.cube.docker.impl.client.config.Await;
+import org.arquillian.cube.docker.impl.client.containerobject.dsl.Container;
+import org.arquillian.cube.docker.impl.client.containerobject.dsl.ContainerBuilder;
+
+@SuppressWarnings("WeakerAccess")
+public final class ContainerFactory {
+
+    public static final String BITCOIN_NODE_CONTAINER_NAME = "bisq-api-bitcoin-node";
+    public static final String BITCOIN_NODE_HOST_NAME = "bitcoin";
+    public static final String SEED_NODE_CONTAINER_NAME = "bisq-seednode";
+    public static final String SEED_NODE_HOST_NAME = SEED_NODE_CONTAINER_NAME;
+    public static final String SEED_NODE_ADDRESS = SEED_NODE_HOST_NAME + ":8000";
+    public static final String CONTAINER_NAME_PREFIX = "bisq-api-";
+    public static final String API_IMAGE = "bisq/api";
+    public static final String ENV_NODE_PORT_KEY = "NODE_PORT";
+    public static final String ENV_ENABLE_HTTP_API_EXPERIMENTAL_FEATURES_KEY = "ENABLE_HTTP_API_EXPERIMENTAL_FEATURES";
+    public static final String ENV_HTTP_API_HOST_KEY = "HTTP_API_HOST";
+    public static final String ENV_HTTP_API_HOST_VALUE = "0.0.0.0";
+    public static final String ENV_USE_DEV_PRIVILEGE_KEYS_KEY = "USE_DEV_PRIVILEGE_KEYS";
+    public static final String ENV_USE_DEV_PRIVILEGE_KEYS_VALUE = "true";
+    public static final String ENV_USE_LOCALHOST_FOR_P2P_KEY = "USE_LOCALHOST_FOR_P2P";
+    public static final String ENV_USE_LOCALHOST_FOR_P2P_VALUE = "true";
+    public static final String ENV_BASE_CURRENCY_NETWORK_KEY = "BASE_CURRENCY_NETWORK";
+    public static final String ENV_BASE_CURRENCY_NETWORK_VALUE = "BTC_REGTEST";
+    public static final String ENV_BITCOIN_REGTEST_HOST_KEY = "BITCOIN_REGTEST_HOST";
+    public static final String ENV_BITCOIN_REGTEST_HOST_VALUE = "LOCALHOST";
+    public static final String ENV_BTC_NODES_KEY = "BTC_NODES";
+    public static final String ENV_BTC_NODES_VALUE = "bitcoin:18444";
+    public static final String ENV_SEED_NODES_KEY = "SEED_NODES";
+    public static final String ENV_SEED_NODES_VALUE = SEED_NODE_ADDRESS;
+    public static final String ENV_LOG_LEVEL_KEY = "LOG_LEVEL";
+    public static final String ENV_LOG_LEVEL_VALUE = "warn";
+
+    @SuppressWarnings("WeakerAccess")
+    public static ContainerBuilder.ContainerOptionsBuilder createApiContainerBuilder(String nameSuffix, String portBinding, int nodePort, boolean linkToSeedNode, boolean linkToBitcoin, boolean enableExperimentalFeatures) {
+        ContainerBuilder.ContainerOptionsBuilder containerOptionsBuilder = Container.withContainerName(CONTAINER_NAME_PREFIX + nameSuffix)
+                .fromImage(API_IMAGE)
+                .withPortBinding(portBinding)
+                .withEnvironment(ENV_NODE_PORT_KEY, nodePort)
+                .withEnvironment(ENV_HTTP_API_HOST_KEY, ENV_HTTP_API_HOST_VALUE)
+                .withEnvironment(ENV_ENABLE_HTTP_API_EXPERIMENTAL_FEATURES_KEY, enableExperimentalFeatures)
+                .withEnvironment(ENV_USE_DEV_PRIVILEGE_KEYS_KEY, ENV_USE_DEV_PRIVILEGE_KEYS_VALUE)
+                .withAwaitStrategy(getAwaitStrategy());
+        if (linkToSeedNode) {
+            containerOptionsBuilder.withLink(SEED_NODE_CONTAINER_NAME);
+        }
+        if (linkToBitcoin) {
+            containerOptionsBuilder.withLink(BITCOIN_NODE_CONTAINER_NAME, BITCOIN_NODE_HOST_NAME);
+        }
+        return withRegtestEnv(containerOptionsBuilder);
+    }
+
+    public static Await getAwaitStrategy() {
+        Await awaitStrategy = new Await();
+        awaitStrategy.setStrategy("polling");
+        int sleepPollingTime = 250;
+        awaitStrategy.setIterations(60000 / sleepPollingTime);
+        awaitStrategy.setSleepPollingTime(sleepPollingTime);
+        return awaitStrategy;
+    }
+
+    public static Container createApiContainer(String nameSuffix, String portBinding, int nodePort, boolean linkToSeedNode, boolean linkToBitcoin, boolean enableExperimentalFeatures) {
+        Container container = createApiContainerBuilder(nameSuffix, portBinding, nodePort, linkToSeedNode, linkToBitcoin, enableExperimentalFeatures).build();
+        container.getCubeContainer().setKillContainer(true);
+        return container;
+    }
+
+    public static Container createApiContainer(String nameSuffix, String portBinding, int nodePort, boolean linkToSeedNode, boolean linkToBitcoin) {
+        return createApiContainer(nameSuffix, portBinding, nodePort, linkToSeedNode, linkToBitcoin, true);
+    }
+
+    public static ContainerBuilder.ContainerOptionsBuilder withRegtestEnv(ContainerBuilder.ContainerOptionsBuilder builder) {
+        return builder
+                .withEnvironment(ENV_USE_LOCALHOST_FOR_P2P_KEY, ENV_USE_LOCALHOST_FOR_P2P_VALUE)
+                .withEnvironment(ENV_BASE_CURRENCY_NETWORK_KEY, ENV_BASE_CURRENCY_NETWORK_VALUE)
+                .withEnvironment(ENV_BITCOIN_REGTEST_HOST_KEY, ENV_BITCOIN_REGTEST_HOST_VALUE)
+                .withEnvironment(ENV_BTC_NODES_KEY, ENV_BTC_NODES_VALUE)
+                .withEnvironment(ENV_SEED_NODES_KEY, ENV_SEED_NODES_VALUE)
+                .withEnvironment(ENV_LOG_LEVEL_KEY, ENV_LOG_LEVEL_VALUE);
+    }
+
+}

--- a/api/src/testIntegration/java/bisq/api/http/SwaggerIT.java
+++ b/api/src/testIntegration/java/bisq/api/http/SwaggerIT.java
@@ -1,0 +1,73 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.http;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+
+
+import org.arquillian.cube.docker.impl.client.containerobject.dsl.Container;
+import org.arquillian.cube.docker.impl.client.containerobject.dsl.DockerContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+
+@RunWith(Arquillian.class)
+public class SwaggerIT {
+
+    @DockerContainer
+    private Container alice = ContainerFactory.createApiContainer("alice", "8081->8080", 3333, false, false);
+
+    @InSequence(1)
+    @Test
+    public void getDocs_always_returns200() {
+        given().
+                port(getAlicePort()).
+//
+        when().
+                get("/docs").
+//
+        then().
+                statusCode(200).
+                and().body(containsString("Swagger UI"))
+        ;
+    }
+
+    @InSequence(1)
+    @Test
+    public void getOpenApiJson_always_returns200() {
+        given().
+                port(getAlicePort()).
+//
+        when().
+                get("/openapi.json").
+//
+        then().
+                statusCode(200).
+                and().body("info.title", equalTo("Bisq HTTP API"));
+    }
+
+    private int getAlicePort() {
+        return alice.getBindPort(8080);
+    }
+
+}

--- a/api/src/testIntegration/java/bisq/api/http/UserEndpointIT.java
+++ b/api/src/testIntegration/java/bisq/api/http/UserEndpointIT.java
@@ -25,6 +25,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.isEmptyString;
 
 
@@ -62,7 +63,7 @@ public class UserEndpointIT {
 
     @InSequence(2)
     @Test
-    public void changePassword_missingPayload_returns400() {
+    public void changePassword_missingPayload_returns422() {
         int alicePort = getAlicePort();
         given().
                 port(alicePort).
@@ -73,8 +74,9 @@ public class UserEndpointIT {
                 post("/api/v1/user/password").
 //
         then().
-                statusCode(400).
-                and().body(isEmptyString());
+                statusCode(422).
+                and().body("errors.size", equalTo(1)).
+                and().body("errors[0]", equalTo("Request payload is required"));
 
         verifyThatAuthenticationIsDisabled();
     }

--- a/api/src/testIntegration/java/bisq/api/http/UserEndpointIT.java
+++ b/api/src/testIntegration/java/bisq/api/http/UserEndpointIT.java
@@ -1,0 +1,214 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.http;
+
+import bisq.api.http.model.ChangePassword;
+
+import bisq.common.util.Base64;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.isEmptyString;
+
+
+
+import com.github.javafaker.Faker;
+import io.restassured.http.ContentType;
+import io.restassured.response.Response;
+import org.arquillian.cube.docker.impl.client.containerobject.dsl.Container;
+import org.arquillian.cube.docker.impl.client.containerobject.dsl.DockerContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+
+@RunWith(Arquillian.class)
+public class UserEndpointIT {
+
+    private static String validPassword = new Faker().internet().password();
+    private static String invalidPassword = getRandomPasswordDifferentThan(validPassword);
+    @DockerContainer
+    Container alice = ContainerFactory.createApiContainer("alice", "8081->8080", 3333, false, false);
+
+    private static String getRandomPasswordDifferentThan(String otherPassword) {
+        String newPassword;
+        do {
+            newPassword = new Faker().internet().password();
+        } while (otherPassword.equals(newPassword));
+        return newPassword;
+    }
+
+    @InSequence
+    @Test
+    public void waitForAllServicesToBeReady() throws InterruptedException {
+        ApiTestHelper.waitForAllServicesToBeReady();
+        verifyThatAuthenticationIsDisabled();
+    }
+
+    @InSequence(2)
+    @Test
+    public void changePassword_missingPayload_returns400() {
+        int alicePort = getAlicePort();
+        given().
+                port(alicePort).
+                contentType(ContentType.JSON).
+                accept(ContentType.JSON).
+//
+        when().
+                post("/api/v1/user/password").
+//
+        then().
+                statusCode(400).
+                and().body(isEmptyString());
+
+        verifyThatAuthenticationIsDisabled();
+    }
+
+    @InSequence(3)
+    @Test
+    public void changePassword_settingFirstPassword_enablesAuthentication() {
+        given().
+                port(getAlicePort()).
+                body(new ChangePassword(validPassword, null)).
+                contentType(ContentType.JSON).
+//
+        when().
+                post("/api/v1/user/password").
+//
+        then().
+                statusCode(204).
+                and().body(isEmptyString());
+
+        verifyThatAuthenticationIsEnabled();
+        verifyThatPasswordIsValid(validPassword);
+    }
+
+    @InSequence(4)
+    @Test
+    public void changePassword_invalidOldPassword_returns401() {
+        String newPassword = getRandomPasswordDifferentThan(validPassword);
+        given().
+                port(getAlicePort()).
+                body(new ChangePassword(newPassword, invalidPassword)).
+                contentType(ContentType.JSON).
+//
+        when().
+                post("/api/v1/user/password").
+//
+        then().
+                statusCode(401);
+
+        verifyThatAuthenticationIsEnabled();
+        verifyThatPasswordIsValid(validPassword);
+        verifyThatPasswordIsInvalid(newPassword);
+    }
+
+    @InSequence(4)
+    @Test
+    public void changePassword_emptyOldPassword_returns401() {
+        String newPassword = getRandomPasswordDifferentThan(validPassword);
+        given().
+                port(getAlicePort()).
+                body(new ChangePassword(newPassword, null)).
+                contentType(ContentType.JSON).
+//
+        when().
+                post("/api/v1/user/password").
+//
+        then().
+                statusCode(401);
+
+        verifyThatAuthenticationIsEnabled();
+        verifyThatPasswordIsValid(validPassword);
+        verifyThatPasswordIsInvalid(newPassword);
+    }
+
+    @InSequence(5)
+    @Test
+    public void changePassword_settingAnotherPassword_keepsAuthenticationEnabled() {
+        String oldPassword = validPassword;
+        String newPassword = getRandomPasswordDifferentThan(validPassword);
+        validPassword = newPassword;
+        invalidPassword = getRandomPasswordDifferentThan(validPassword);
+        given().
+                port(getAlicePort()).
+                body(new ChangePassword(newPassword, oldPassword)).
+                contentType(ContentType.JSON).
+//
+        when().
+                post("/api/v1/user/password").
+//
+        then().
+                statusCode(204);
+
+        verifyThatPasswordIsInvalid(oldPassword);
+        verifyThatPasswordIsValid(newPassword);
+        verifyThatAuthenticationIsEnabled();
+    }
+
+    @InSequence(6)
+    @Test
+    public void changePassword_validOldPasswordAndNoNewPassword_disablesAuthentication() {
+        given().
+                port(getAlicePort()).
+                body(new ChangePassword(null, validPassword)).
+                contentType(ContentType.JSON).
+//
+        when().
+                post("/api/v1/user/password").
+//
+        then().
+                statusCode(204);
+
+        verifyThatAuthenticationIsDisabled();
+    }
+
+    private void verifyThatAuthenticationIsDisabled() {
+        authenticationVerificationRequest().then().statusCode(200);
+    }
+
+    private void verifyThatAuthenticationIsEnabled() {
+        authenticationVerificationRequest().then().statusCode(401);
+    }
+
+    private void verifyThatPasswordIsInvalid(String password) {
+        passwordVerificationRequest(password).then().statusCode(401);
+    }
+
+    private void verifyThatPasswordIsValid(String password) {
+        passwordVerificationRequest(password).then().statusCode(200);
+    }
+
+    private Response authenticationVerificationRequest() {
+        return given().port(getAlicePort()).when().get("/api/v1/version");
+    }
+
+    private Response passwordVerificationRequest(String password) {
+        String authHeader = "Basic " + Base64.encode((":" + password).getBytes());
+        return given().port(getAlicePort()).
+//
+        when().
+                        header("authorization", authHeader).
+                        get("/api/v1/version");
+    }
+
+    private int getAlicePort() {
+        return alice.getBindPort(8080);
+    }
+
+}

--- a/api/src/testIntegration/java/bisq/api/http/VersionEndpointIT.java
+++ b/api/src/testIntegration/java/bisq/api/http/VersionEndpointIT.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.http;
+
+import bisq.common.app.Version;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.isA;
+
+
+
+import org.arquillian.cube.docker.impl.client.containerobject.dsl.Container;
+import org.arquillian.cube.docker.impl.client.containerobject.dsl.DockerContainer;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
+
+@RunWith(Arquillian.class)
+public class VersionEndpointIT {
+
+    @DockerContainer
+    private Container alice = ContainerFactory.createApiContainer("alice", "8081->8080", 3333, false, false);
+
+    @InSequence
+    @Test
+    public void waitForAllServicesToBeReady() throws InterruptedException {
+        ApiTestHelper.waitForAllServicesToBeReady();
+    }
+
+    @InSequence(1)
+    @Test
+    public void getVersionDetails_always_returns200() {
+        given().
+                port(getAlicePort()).
+//
+        when().
+                get("/api/v1/version").
+//
+        then().
+                statusCode(200).
+                and().body("application", equalTo(Version.VERSION)).
+                and().body("network", equalTo(Version.P2P_NETWORK_VERSION)).
+                and().body("p2PMessage", isA(Integer.class)).
+                and().body("localDB", equalTo(Version.LOCAL_DB_VERSION)).
+                and().body("tradeProtocol", equalTo(Version.TRADE_PROTOCOL_VERSION));
+    }
+
+    private int getAlicePort() {
+        return alice.getBindPort(8080);
+    }
+
+}

--- a/api/src/testIntegration/java/bisq/api/http/arquillian/CubeLogger.java
+++ b/api/src/testIntegration/java/bisq/api/http/arquillian/CubeLogger.java
@@ -1,0 +1,47 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.http.arquillian;
+
+import org.arquillian.cube.CubeController;
+import org.arquillian.cube.spi.event.lifecycle.BeforeStop;
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.test.spi.TestClass;
+
+public class CubeLogger {
+
+    private static boolean isExtensionEnabled(ArquillianDescriptor arquillianDescriptor) {
+        String dumpContainerLogs = arquillianDescriptor.extension("cubeLogger").getExtensionProperty("enable");
+        return Boolean.parseBoolean(dumpContainerLogs);
+    }
+
+    @SuppressWarnings({"unused", "UnusedParameters"})
+    public void beforeContainerStop(@Observes BeforeStop event, CubeController cubeController, ArquillianDescriptor arquillianDescriptor, TestClass testClass) {
+        if (isExtensionEnabled(arquillianDescriptor)) {
+            String cubeId = event.getCubeId();
+            System.out.println("=====================================================================================");
+            System.out.println("Start of container logs: " + cubeId + " from " + testClass.getName());
+            System.out.println("=====================================================================================");
+            cubeController.copyLog(cubeId, false, true, true, true, -1, System.out);
+            System.out.println("=====================================================================================");
+            System.out.println("End of container logs: " + cubeId + " from " + testClass.getName());
+            System.out.println("=====================================================================================");
+        }
+    }
+
+}

--- a/api/src/testIntegration/java/bisq/api/http/arquillian/CubeLoggerExtension.java
+++ b/api/src/testIntegration/java/bisq/api/http/arquillian/CubeLoggerExtension.java
@@ -1,0 +1,28 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.api.http.arquillian;
+
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+public class CubeLoggerExtension implements LoadableExtension {
+
+    @Override
+    public void register(ExtensionBuilder extensionBuilder) {
+        extensionBuilder.observer(CubeLogger.class);
+    }
+}

--- a/api/src/testIntegration/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/api/src/testIntegration/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+bisq.api.http.arquillian.CubeLoggerExtension

--- a/api/src/testIntegration/resources/arquillian.xml
+++ b/api/src/testIntegration/resources/arquillian.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://www.jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <extension qualifier="docker">
+        <property name="definitionFormat">CUBE</property>
+        <property name="serverUri">unix:///var/run/docker.sock</property>
+        <property name="tlsVerify">false</property>
+    </extension>
+    <extension qualifier="cubeLogger">
+        <property name="enable">true</property>
+    </extension>
+</arquillian>

--- a/api/src/testIntegration/resources/logback-test.xml
+++ b/api/src/testIntegration/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="WARN">
+        <appender-ref ref="console"/>
+    </root>
+
+    <logger name="org.apache.http" level="WARN"/>
+    <logger name="com.github.dockerjava" level="WARN"/>
+</configuration>

--- a/build.gradle
+++ b/build.gradle
@@ -291,7 +291,6 @@ configure(project(':api')) {
         }
         compile 'org.glassfish.jersey.media:jersey-media-json-jackson:2.27'
         compile 'org.glassfish.jersey.media:jersey-media-multipart:2.27'
-        compile 'org.glassfish.jersey.ext:jersey-bean-validation:2.27'
 
         compile 'io.swagger.core.v3:swagger-annotations:2.0.6'
         compile 'javax.xml.bind:jaxb-api:2.3.0'

--- a/build.gradle
+++ b/build.gradle
@@ -305,7 +305,46 @@ configure(project(':api')) {
         testAnnotationProcessor 'org.projectlombok:lombok:1.18.2'
         testCompile "com.github.javafaker:javafaker:0.14"
         testCompile "org.apache.commons:commons-lang3:$langVersion"
+        testCompile "org.arquillian.universe:arquillian-junit:1.2.0.1"
+        testCompile "org.arquillian.universe:arquillian-cube-docker:1.2.0.1"
+        testCompile "org.arquillian.cube:arquillian-cube-docker:1.15.3"
+        testCompile "io.rest-assured:rest-assured:3.0.2"
         testCompile 'io.swagger.core.v3:swagger-jaxrs2:2.0.6' //needed to generate documentation using SwaggerGenerator
+    }
+
+    sourceSets {
+        testIntegration {
+            java.srcDir 'src/testIntegration/java'
+            resources.srcDir 'src/testIntegration/resources'
+            compileClasspath += sourceSets.main.output + configurations.testRuntimeClasspath
+            runtimeClasspath += output + compileClasspath
+        }
+    }
+
+    task testIntegration(type: Test) {
+        group = LifecycleBasePlugin.VERIFICATION_GROUP
+        description = 'Runs the integration tests.'
+
+        maxHeapSize = '1024m'
+
+        testClassesDir = sourceSets.testIntegration.output.classesDir
+        classpath = sourceSets.testIntegration.runtimeClasspath
+
+        binResultsDir = file("$buildDir/api/integration-test-results/binary/testIntegration")
+
+        reports {
+            html.destination = "$buildDir/api/reports/integration-test"
+            junitXml.destination = "$buildDir/api/integration-test-results"
+        }
+
+        systemProperties = [
+            CUBE_LOGGER_ENABLE: System.getenv('CUBE_LOGGER_ENABLE')
+        ]
+
+        testLogging.showStandardStreams = true
+        testLogging.exceptionFormat = 'full'
+
+        mustRunAfter tasks.test
     }
 }
 

--- a/core/src/main/java/bisq/core/exceptions/ConstraintViolationException.java
+++ b/core/src/main/java/bisq/core/exceptions/ConstraintViolationException.java
@@ -1,0 +1,74 @@
+/*
+ * This file is part of Bisq.
+ *
+ * Bisq is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or (at
+ * your option) any later version.
+ *
+ * Bisq is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package bisq.core.exceptions;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ConstraintViolationException extends ValidationException {
+    private Set<ConstraintViolation> constraintViolations;
+
+
+    public ConstraintViolationException(Set<ConstraintViolation> constraintViolations) {
+        this.constraintViolations = constraintViolations;
+    }
+
+    public Set<ConstraintViolation> getConstraintViolations() {
+        return null == constraintViolations ? Collections.emptySet() : constraintViolations;
+    }
+
+
+    public static class ConstraintViolation {
+        private String propertyPath;
+        private String message;
+
+        private ConstraintViolation(String propertyPath, String message) {
+            this.propertyPath = propertyPath;
+            this.message = message;
+        }
+
+        public String getPropertyPath() {
+            return propertyPath;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+
+    public static class Builder {
+        private Set<ConstraintViolation> constraintViolations;
+
+        public Builder addViolation(String propertyPath, String message) {
+            if (null == constraintViolations)
+                constraintViolations = new HashSet<>();
+            constraintViolations.add(new ConstraintViolation(propertyPath, message));
+            return this;
+        }
+
+        public ConstraintViolationException build() {
+            return new ConstraintViolationException(constraintViolations);
+        }
+
+        public void throwIfAnyValidation() {
+            if (null != constraintViolations && !constraintViolations.isEmpty())
+                throw build();
+        }
+    }
+}

--- a/core/src/main/java/bisq/core/exceptions/ValidationException.java
+++ b/core/src/main/java/bisq/core/exceptions/ValidationException.java
@@ -15,21 +15,25 @@
  * along with Bisq. If not, see <http://www.gnu.org/licenses/>.
  */
 
-package bisq.api.http.model;
+package bisq.core.exceptions;
 
-public class ChangePassword implements Validatable {
-
-    public String newPassword;
-    public String oldPassword;
-
-    public ChangePassword() {
+/**
+ * Copy of ValidationException from javax.validation:validation-api
+ */
+public class ValidationException extends RuntimeException {
+    public ValidationException(String message) {
+        super(message);
     }
 
-    public ChangePassword(String newPassword, String oldPassword) {
-        this.newPassword = newPassword;
-        this.oldPassword = oldPassword;
+    public ValidationException() {
+        super();
     }
 
-    public void validate() {
+    public ValidationException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public ValidationException(Throwable cause) {
+        super(cause);
     }
 }

--- a/core/src/test/java/bisq/core/exceptions/ConstraintViolationExceptionTest.java
+++ b/core/src/test/java/bisq/core/exceptions/ConstraintViolationExceptionTest.java
@@ -1,0 +1,57 @@
+package bisq.core.exceptions;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+public class ConstraintViolationExceptionTest {
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Test
+    public void builderThrowIfAnyViolation_noViolations_doesNotThrow() {
+        //        Given
+        ConstraintViolationException.Builder builder = new ConstraintViolationException.Builder();
+
+        //        When
+        builder.throwIfAnyValidation();
+    }
+
+    @Test
+    public void builderThrowIfAnyViolation_violationAdded_doesNotThrow() {
+        //        Given
+        ConstraintViolationException.Builder builder = new ConstraintViolationException.Builder();
+        String must_not_be_null = "must not be null";
+        String username = "username";
+        builder.addViolation(username, must_not_be_null);
+        String should_be_an_email = "should be an email";
+        String address = "address";
+        builder.addViolation(address, should_be_an_email);
+        //        When
+        try {
+            builder.throwIfAnyValidation();
+            fail("Expected ConstraintViolationException");
+        } catch (ConstraintViolationException e) {
+            //        Then
+            assertNull(e.getMessage());
+            Set<ConstraintViolationException.ConstraintViolation> constraintViolations = e.getConstraintViolations();
+            assertNotNull(constraintViolations);
+            assertEquals(2, constraintViolations.size());
+            Set<String> resultMessageSet = constraintViolations.stream().map(ConstraintViolationException.ConstraintViolation::getMessage).collect(Collectors.toSet());
+            Set<String> resultPropertyPathSet = constraintViolations.stream().map(ConstraintViolationException.ConstraintViolation::getPropertyPath).collect(Collectors.toSet());
+            assertEquals(new HashSet<>(List.of(must_not_be_null, should_be_an_email)), resultMessageSet);
+            assertEquals(new HashSet<>(List.of(username, address)), resultPropertyPathSet);
+        }
+    }
+}


### PR DESCRIPTION
Introduce minimal solution for input validation.
With removal of jersey-bean-validation we remove few other transitive dependencies.

This PR is based on top of https://github.com/bisq-network/incubator-bisq-api/pull/14 so please merge that one first.